### PR TITLE
チャレンジズコントローラ作成（delete以外）ビューファイルとの連携確認　ルーティング作成

### DIFF
--- a/app/Http/Controllers/ChallengesController.php
+++ b/app/Http/Controllers/ChallengesController.php
@@ -3,40 +3,159 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use App\Http\Requests\ChallengesRequest;
+// use App\Http\Requests\ChallengesRequest;
 use App\User;
 use App\Recipe;
 use App\Challenge;
+use Carbon\Carbon;
 
 class ChallengesController extends Controller
 {
-    public function create()
+    
+    public function create($recipe_id)
     {
-        //
+        $recipe = Recipe::find($recipe_id);
+
+        return view('challenges.create',[
+            'recipe' => $recipe,
+        ]);
     }
 
-    public function store(ChallengesRequest $request)
+    public function store(Request $request, $recipe_id)
     {
-        //
+        
+        $request->validate([
+            'impression'=> 'required|max:3000',
+            'challenge_img' => 'required',
+        ],
+        [
+            'impression.required' => 'コメントを入力してください。',
+            'impression.max' => 'コメントは3000文字以内で入力してください。',
+            'challenge_img.required' => '写真を添付してください。',
+        ]);
+
+        try {
+			// トランザクション開始
+			\DB::beginTransaction();
+
+			$challenge = new Challenge;	
+			$challenge->user_id = \Auth::user()->id;
+			$challenge->recipe_id = $recipe_id;
+            $challenge->impression = $request->impression;
+          
+
+			$challengeImg = $request->challenge_img;
+			$extension = $challengeImg->guessExtension();
+         
+            //ファイル名を一意のものにする
+            $user_id = \Auth::user()->id;
+            $date = Carbon::now();
+            $date = date('Ymdhis');
+			$fileName = "challenge_{$user_id}_{$date}.{$extension}";
+            $challenge->img = $fileName;
+            
+            // imgがnullを許容しないのでここで$challengeを初めて保存
+			$challenge->save();
+
+			// imgファイル自体を保存
+			$challengeImg->storeAs('public/challenges_img', $fileName);
+
+			// トランザクションの保存処理を実行
+			\DB::commit();
+
+     
+			return redirect(route('challenges.show', [
+                'challenge_id' => $challenge->id,
+                'recipe_id' => $recipe_id,
+			]))->with('status', '「作ってみた」を新規登録しました');
+
+		} catch (\Exception $e) {
+			// エラー発生時は、DBへの保存処理が無かったことにする（ロールバック）
+			\DB::rollBack();
+			throw $e;
+		}
+
     }
 
-    public function show($id)
+    public function show($recipe_id, $challenge_id)
     {
-        //
+        $recipe = Recipe::find($recipe_id);
+        $challenge = Challenge::find($challenge_id);
+        $user = User::find($challenge->user_id);
+        
+        return view('challenges.show', [
+            'recipe' => $recipe,
+            'challenge' => $challenge,
+            'user' => $user,
+        ]);
     }
 
-    public function edit($id)
+    public function edit($recipe_id, $challenge_id)
     {
-        //
+        $challenge = Challenge::find($challenge_id);
+        $recipe = Recipe::find($recipe_id);
+        $recipe_id = $recipe->id;
+
+        return view('challenges.edit', [
+            'challenge' => $challenge,
+            'recipe_id' => $recipe_id,
+        ]);
     }
 
-    public function update(ChallengesRequest $request, $id)
+    public function update(Request $request, $recipe_id, $challenge_id)
     {
-        //
+
+        $request->validate([
+            'impression'=> 'required|max:3000',
+        ],
+        [
+            'impression.required' => 'コメントを入力してください。',
+            'impression.max' => 'コメントは3000文字以内で入力してください。',
+        ]);
+
+        try {
+			// トランザクション開始
+            \DB::beginTransaction();
+            
+            $challenge = challenge::find($challenge_id);
+            $challenge->impression = $request->impression;
+
+            if(!isset($request->challenge_img)){
+                    $challenge->img = $challenge->img;
+            }else{
+                $challengeImg = $request->challenge_img;
+                $extension = $challengeImg->guessExtension();
+            
+                //ファイル名を一意のものにする
+                $user_id = \Auth::user()->id;
+                $date = Carbon::now();
+                $date = date('Ymdhis');
+                $fileName = "challenge_{$user_id}_{$date}.{$extension}";
+                $challenge->img = $fileName;
+
+                // imgファイル自体を保存
+                $challengeImg->storeAs('public/challenges_img', $fileName);
+                }
+
+            $challenge->save();
+
+            // トランザクションの保存処理を実行
+            \DB::commit();
+                
+            return redirect(route('challenges.show', [
+                'challenge_id' => $challenge->id,
+                'recipe_id' => $recipe_id,
+            ]))->with('status', '「作ってみた」を更新しました');
+
+            } catch (\Exception $e) {
+            // エラー発生時は、DBへの保存処理が無かったことにする（ロールバック）
+            \DB::rollBack();
+            throw $e;
+            }
     }
 
-    public function destroy($id)
+    public function destroy($challenge_id)
     {
-        //
+        
     }
 }

--- a/resources/views/challenges/create.blade.php
+++ b/resources/views/challenges/create.blade.php
@@ -8,18 +8,18 @@
 
           <h3 class="mb-5">作ってみた投稿</h3>
 
-          <form method="post" action="#" enctype="multipart/form-data">
+          <form method="post" action="{{route('challenges.store',['recipe_id'=>$recipe->id])}}" enctype="multipart/form-data">
           @csrf
             <div id="form-group my-5">
               <label for="comment">コメント <span class="badge badge-danger">必須</span></label>
               <!-- <button class="needbtn ml-4">必須</button> -->
-              <textarea id="comment" class="form-control" cols="10" rows="10" placeholder="作ってみた感想などをお書きください。"></textarea>
+              <textarea id="comment" name="impression" class="form-control" cols="10" rows="10" placeholder="作ってみた感想などをお書きください。"></textarea>
             </div>
 
             <div class="form-group my-5">
               <label for="file">この料理の完成写真 <span class="badge badge-danger">必須</span></label>
               <!-- <button class="needbtn ml-4">必須</button> -->
-              <input type="file" id="file" class="form-control-file">
+              <input type="file" id="file" name="challenge_img" class="form-control-file">
             </div>
 
             <div class="text-center my-5">

--- a/resources/views/challenges/edit.blade.php
+++ b/resources/views/challenges/edit.blade.php
@@ -7,17 +7,22 @@
         <div class="card-body col-md-10 my-3">
           <h3 class="mb-5">作ってみた投稿<span class="editbutton ml-4">修正</span></h3>
 
-          <form action="">
+          <form method="post" action="{{route('challenges.update',['recipe_id'=>$recipe_id,'challenge_id'=>$challenge->id])}}" enctype="multipart/form-data">
+            @csrf
             <div id="form-group my-5">
-              <label for="comment">コメント</label>
-              <button class="needbtn ml-4">必須</button>
-              <textarea id="comment" class="form-control" cols="10" rows="10">{{ $challenge->impression }}</textarea>
+              <label for="comment">コメント <span class="badge badge-danger">必須</span></label>
+              <!-- <button class="needbtn ml-4">必須</button> -->
+              <textarea id="comment" name="impression" class="form-control" cols="10" rows="10">{{ $challenge->impression }}</textarea>
             </div>
 
             <div class="form-group my-5">
-              <label for="file1">この料理の完成写真</label>
-              <button class="needbtn ml-4">必須</button>
-              <input type="file" id="file" class="form-control-file">
+              <div>
+                <p>現在の画像</p>
+                <img class="mb-3 img-fluid" src="/storage/challenges_img/{{ $challenge->img }}" alt="NO IMAGE" style="width: 20%;">
+              </div>
+              <label for="file1">必要であれば画像を変更してください</label>
+              <!-- <button class="needbtn ml-4">必須</button> -->
+              <input type="file" id="file" class="form-control-file" name="challenge_img">
             </div>
 
             <div class="text-center my-5">
@@ -25,8 +30,10 @@
             </div>
 
           </form>
+
         </div>
       </div>
     </div>
   </div>
 @endsection
+

--- a/resources/views/challenges/show.blade.php
+++ b/resources/views/challenges/show.blade.php
@@ -16,10 +16,10 @@
 
           <!-- ! データ -->
           <h3>
-            <span class="mr-5">{{ $recipe_user->name }}の</span><span>{{ $recipe->name }}</span>
+            <span class="mr-5">{{$user->name}}の</span><span>{{ $recipe->name }}</span>
           </h3>
 
-          <img class="mt-3" src="" alt="NO IMAGE" style="width: 80%; height: 50%;">
+          <img class="mt-3" src="/storage/challenges_img/{{ $challenge->img }}" alt="NO IMAGE" style="width: 80%; height: 50%;">
           <p class="text-justify mt-4">
             <span class="comment">{{ $challenge->impression }}</span>
           </p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,10 +19,12 @@ Route::get('/recipes/create', 'RecipesController@create')->name('recipes.create'
 Route::post('/recipes/store', 'RecipesController@store')->name('recipes.store');
 Route::get('/recipes/show/{id}', 'RecipesController@show')->name('recipes.show')->where('id', '[0-9]+');
 
-// Route::resoure('/recipes/{recipe_id}/challenges', 'ChallengesController', ['except' => ['index']]);
+
 Route::get('recipes/{recipe_id}/challenges/create', 'ChallengesController@create');
+Route::post('recipes/{recipe_id}/challenges/store', 'ChallengesController@store')->name('challenges.store');
+Route::get('recipes/{recipe_id}/challenges/show/{challenge_id}', 'ChallengesController@show')->name('challenges.show');
 Route::get('recipes/{recipe_id}/challenges/edit/{challenge_id}', 'ChallengesController@edit');
-Route::get('recipes/{recipe_id}/challenges/show/{challenge_id}', 'ChallengesController@show');
+Route::post('recipes/{recipe_id}/challenges/update/{challenge_id}', 'ChallengesController@update')->name('challenges.update');
 
 
 Auth::routes();


### PR DESCRIPTION
##チャレンジズコントローラーの作成

【進捗状況】
create,store,show,edit,updateメソッドから、正しくviewが表示されるように作成しました。
（※deleteのみ未完成です。）

【実装概要】
・投稿編集の際に画像はそのままでも投稿できるように変更しました。（updateメソッドで条件分岐）

・それに伴い、storeメソッドとupdateメソッドでimgファイルに対するバリデーションの条件(requiredかどうか)が
異なるため、コントローラで直接バリデーションチェックを行っています。

・deleteはメソッドの処理がうまくいかなかったため、保留しています。

【今後予定】
マージ後、
deleteの処理の確認
favorite,commentの開発に移っていきます。

ご確認のほどよろしくお願い致します。
