### PR TITLE
チャレンジズコントローラーの修正（URL短縮　リクエスト作成等）

### DIFF
--- a/app/Http/Controllers/ChallengesController.php
+++ b/app/Http/Controllers/ChallengesController.php
@@ -15,17 +15,18 @@ class ChallengesController extends Controller
     
     public function create(Request $request)
     {
-        $recipe_id = $request->query('recipe_id');
-        $recipe = Recipe::find($recipe_id);
+        $recipe = Recipe::find($request->recipe_id);
         if($recipe == null) {
             // statusを持たせてレシピ一覧ページにリダイレクトさせた方が良さそうですが、現在当該ページが制作されていないため、abort処理。
             abort(404, "ご指定のレシピが存在しません。");
-        } else {
+        }  
             return view('challenges.create',[
                 'recipe' => $recipe,
             ]);
-        }
+        
     }
+
+
 
     public function store(ChallengesStoreRequest $request)
     {

--- a/app/Http/Requests/ChallengesStoreRequest.php
+++ b/app/Http/Requests/ChallengesStoreRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+
+class ChallengesStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+			'impression'  => 'required|string|max:3000',
+            'challenge_img' => 'required|mimes:jpg,jpeg,png,gif',
+            'recipe_id' => 'required',
+        ];
+    }
+
+    public function messages() 
+    {
+        return [
+            'impression.required' => 'コメントを入力してください',
+            'impression.max:3000' => '3000文字以下で入力してください',
+            'challenge_img.required'  => '写真を添付してください',
+            'recipe_id.required' => 'レシピが指定されていません',
+        ];
+    }
+    
+}
+

--- a/app/Http/Requests/ChallengesUpdateRequest.php
+++ b/app/Http/Requests/ChallengesUpdateRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ChallengesUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'impression'  => 'required|string|max:3000',
+        ];
+    }
+
+    public function messages() 
+    {
+        return [
+            'impression.required' => 'コメントを入力してください',
+            'impression.max:3000' => '3000文字以下で入力してください',
+        ];
+    }
+}

--- a/resources/views/challenges/create.blade.php
+++ b/resources/views/challenges/create.blade.php
@@ -14,13 +14,11 @@
 
             <div id="form-group my-5">
               <label for="comment">コメント <span class="badge badge-danger">必須</span></label>
-              <!-- <button class="needbtn ml-4">必須</button> -->
               <textarea id="comment" name="impression" class="form-control" cols="10" rows="10" placeholder="作ってみた感想などをお書きください。"></textarea>
             </div>
 
             <div class="form-group my-5">
               <label for="file">この料理の完成写真 <span class="badge badge-danger">必須</span></label>
-              <!-- <button class="needbtn ml-4">必須</button> -->
               <input type="file" id="file" name="challenge_img" class="form-control-file">
             </div>
 

--- a/resources/views/challenges/create.blade.php
+++ b/resources/views/challenges/create.blade.php
@@ -8,8 +8,10 @@
 
           <h3 class="mb-5">作ってみた投稿</h3>
 
-          <form method="post" action="{{route('challenges.store',['recipe_id'=>$recipe->id])}}" enctype="multipart/form-data">
+          <form method="post" action="{{route('challenges.store')}}" enctype="multipart/form-data">
           @csrf
+            <input type="hidden" name="recipe_id" value="{{$recipe->id}}">
+
             <div id="form-group my-5">
               <label for="comment">コメント <span class="badge badge-danger">必須</span></label>
               <!-- <button class="needbtn ml-4">必須</button> -->

--- a/resources/views/challenges/edit.blade.php
+++ b/resources/views/challenges/edit.blade.php
@@ -7,11 +7,10 @@
         <div class="card-body col-md-10 my-3">
           <h3 class="mb-5">作ってみた投稿<span class="editbutton ml-4">修正</span></h3>
 
-          <form method="post" action="{{route('challenges.update',['recipe_id'=>$recipe_id,'challenge_id'=>$challenge->id])}}" enctype="multipart/form-data">
+          <form method="post" action="{{route('challenges.update',['challenge_id'=>$challenge->id])}}" enctype="multipart/form-data">
             @csrf
             <div id="form-group my-5">
               <label for="comment">コメント <span class="badge badge-danger">必須</span></label>
-              <!-- <button class="needbtn ml-4">必須</button> -->
               <textarea id="comment" name="impression" class="form-control" cols="10" rows="10">{{ $challenge->impression }}</textarea>
             </div>
 
@@ -21,16 +20,13 @@
                 <img class="mb-3 img-fluid" src="/storage/challenges_img/{{ $challenge->img }}" alt="NO IMAGE" style="width: 20%;">
               </div>
               <label for="file1">必要であれば画像を変更してください</label>
-              <!-- <button class="needbtn ml-4">必須</button> -->
               <input type="file" id="file" class="form-control-file" name="challenge_img">
             </div>
 
             <div class="text-center my-5">
               <button type="submit">送信</button>
             </div>
-
           </form>
-
         </div>
       </div>
     </div>

--- a/resources/views/recipes/show.blade.php
+++ b/resources/views/recipes/show.blade.php
@@ -41,10 +41,7 @@
       </div>
       <div class="row">
         <div class="col-sm-12">
-          <form method="get" action="{{ route('challenges.create') }}">
-          <input type="hidden" name="recipe_id" value="{{$recipe->id}}">
-            <button type="submit" class="btn btn-lg btn-info" style="width: 100%; color: white;">自分の「作ってみた」を投稿する</button>
-          </form>
+        <button onclick="location.href='{{ route('challenges.create', ['recipe_id' => $recipe->id]) }}'" class="btn btn-lg btn-info" style="width: 100%; color: #fff;">「作ってみた」の投稿はこちら</button>       
         </div>
       </div>
     </div>

--- a/resources/views/recipes/show.blade.php
+++ b/resources/views/recipes/show.blade.php
@@ -39,6 +39,14 @@
           </div>
         </div>
       </div>
+      <div class="row">
+        <div class="col-sm-12">
+          <form method="get" action="{{ route('challenges.create') }}">
+          <input type="hidden" name="recipe_id" value="{{$recipe->id}}">
+            <button type="submit" class="btn btn-lg btn-info" style="width: 100%; color: white;">自分の「作ってみた」を投稿する</button>
+          </form>
+        </div>
+      </div>
     </div>
   </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,11 +20,11 @@ Route::post('/recipes/store', 'RecipesController@store')->name('recipes.store');
 Route::get('/recipes/show/{id}', 'RecipesController@show')->name('recipes.show')->where('id', '[0-9]+');
 
 
-Route::get('recipes/{recipe_id}/challenges/create', 'ChallengesController@create');
-Route::post('recipes/{recipe_id}/challenges/store', 'ChallengesController@store')->name('challenges.store');
-Route::get('recipes/{recipe_id}/challenges/show/{challenge_id}', 'ChallengesController@show')->name('challenges.show');
-Route::get('recipes/{recipe_id}/challenges/edit/{challenge_id}', 'ChallengesController@edit');
-Route::post('recipes/{recipe_id}/challenges/update/{challenge_id}', 'ChallengesController@update')->name('challenges.update');
+Route::get('challenges/create', 'ChallengesController@create')->name('challenges.create');
+Route::post('challenges/store', 'ChallengesController@store')->name('challenges.store');
+Route::get('challenges/show/{challenge_id}', 'ChallengesController@show')->name('challenges.show');
+Route::get('challenges/edit/{challenge_id}', 'ChallengesController@edit');
+Route::post('challenges/update/{challenge_id}', 'ChallengesController@update')->name('challenges.update');
 
 
 Auth::routes();


### PR DESCRIPTION
##チャレンジズコントローラー、ご指摘のあった箇所を直しました。

【変更箇所】
★（ご指摘のあった２点）
・show,edit,updateのルーティングの短縮（不要な recipe_idを削除しました）
・ChallengesStoreRequestとChallengesUpdateRequestをそれぞれ作成

●（追加で変更した点）
・create,storeのルーティングをクエリパラメータで渡すことで短縮
・指定のURLが存在しなかった場合にabortで404エラーメッセージを表示

【今後の予定】
deleteメソッドの実装
Favoritesの開発

お忙しいところ恐縮ですが、ご確認のほどよろしくお願い致します。