### PR TITLE
作ってみたに関する削除機能　ユーザーチェック機能実装

### DIFF
--- a/app/Http/Controllers/ChallengesController.php
+++ b/app/Http/Controllers/ChallengesController.php
@@ -119,7 +119,7 @@ class ChallengesController extends Controller
 
             if(!isset($request->challenge_img)){
                 $challenge->img = $challenge->img;
-            }else{
+            }
                 $challengeImg = $request->challenge_img;
                 $extension = $challengeImg->guessExtension();
             
@@ -133,7 +133,7 @@ class ChallengesController extends Controller
 
                 // imgファイル自体を保存
                 $challengeImg->storeAs('public/challenges_img', $fileName);
-                }
+                
 
             $challenge->save();
 

--- a/app/Http/Controllers/ChallengesController.php
+++ b/app/Http/Controllers/ChallengesController.php
@@ -114,12 +114,10 @@ class ChallengesController extends Controller
             // トランザクション開始
             \DB::beginTransaction();
             
-            $challenge = challenge::find($challenge_id);
+            $challenge = Challenge::find($challenge_id);
             $challenge->impression = $request->impression;
 
-            if(!isset($request->challenge_img)){
-                $challenge->img = $challenge->img;
-            }
+            if(isset($request->challenge_img)){
                 $challengeImg = $request->challenge_img;
                 $extension = $challengeImg->guessExtension();
             
@@ -133,7 +131,7 @@ class ChallengesController extends Controller
 
                 // imgファイル自体を保存
                 $challengeImg->storeAs('public/challenges_img', $fileName);
-                
+            }  
 
             $challenge->save();
 

--- a/app/Http/Controllers/ChallengesController.php
+++ b/app/Http/Controllers/ChallengesController.php
@@ -12,84 +12,77 @@ use Carbon\Carbon;
 
 class ChallengesController extends Controller
 {
-    
+
     public function create(Request $request)
     {
         $recipe = Recipe::find($request->recipe_id);
         if($recipe == null) {
             // statusを持たせてレシピ一覧ページにリダイレクトさせた方が良さそうですが、現在当該ページが制作されていないため、abort処理。
             abort(404, "ご指定のレシピが存在しません。");
-        }  
-            return view('challenges.create',[
+        }
+
+        if(!\Auth::check()){
+            return back()->with('status', 'ログインユーザーしか投稿できません');
+        }
+            
+        return view('challenges.create',[
                 'recipe' => $recipe,
-            ]);
-        
+            ]);   
     }
-
-
 
     public function store(ChallengesStoreRequest $request)
     {
-        
         try {
-			// トランザクション開始
+            // トランザクション開始
             \DB::beginTransaction();
             
-            
-            $recipe_id = $request->recipe_id;
-
-			$challenge = new Challenge;	
-			$challenge->user_id = \Auth::user()->id;
-			$challenge->recipe_id = $request->recipe_id;
+            $challenge = new Challenge; 
+            $challenge->user_id = \Auth::user()->id;
+            $challenge->recipe_id = $request->recipe_id;
             $challenge->impression = $request->impression;
-          
 
-			$challengeImg = $request->challenge_img;
-			$extension = $challengeImg->guessExtension();
+            $challengeImg = $request->challenge_img;
+            $extension = $challengeImg->guessExtension();
          
             //ファイル名を一意のものにする
             $user_id = \Auth::user()->id;
             $date = Carbon::now();
             $date = date('Ymdhis');
-			$fileName = "challenge_{$user_id}_{$date}.{$extension}";
+            $fileName = "challenge_{$user_id}_{$date}.{$extension}";
+
             $challenge->img = $fileName;
             
             // imgがnullを許容しないのでここで$challengeを初めて保存
-			$challenge->save();
+            $challenge->save();
 
-			// imgファイル自体を保存
-			$challengeImg->storeAs('public/challenges_img', $fileName);
+            // imgファイル自体を保存
+            $challengeImg->storeAs('public/challenges_img', $fileName);
 
-			// トランザクションの保存処理を実行
-			\DB::commit();
+            // トランザクションの保存処理を実行
+            \DB::commit();
 
-     
-			return redirect(route('challenges.show', [
+            return redirect(route('challenges.show', [
                 'challenge_id' => $challenge->id,
-                'recipe_id' => $recipe_id,
-			]))->with('status', '「作ってみた」を新規登録しました');
-
-		} catch (\Exception $e) {
-			// エラー発生時は、DBへの保存処理が無かったことにする（ロールバック）
-			\DB::rollBack();
-			throw $e;
-		}
-
+            ]))->with('status', '「作ってみた」を新規登録しました');
+        } catch (\Exception $e) {
+            // エラー発生時は、DBへの保存処理が無かったことにする（ロールバック）
+            \DB::rollBack();
+            throw $e;
+        }
     }
 
     public function show($challenge_id)
     {
-
         $challenge = Challenge::find($challenge_id);
 
         if($challenge == null) {
             // statusを持たせてレシピ一覧ページにリダイレクトさせた方が良さそうですが、現在当該ページが制作されていないため、abort処理。
             abort(404, "ご指定の「作ってみた」が存在しません。");
         }
+
         $user = User::find($challenge->user_id);
         $recipe = Recipe::find($challenge->recipe_id);
         
-       
         return view('challenges.show', [
             'challenge' => $challenge,
             'user' => $user,
@@ -106,23 +99,26 @@ class ChallengesController extends Controller
             abort(404, "ご指定の「作ってみた」が存在しません。");
         } 
 
+        if(\Auth::id() == $challenge->user_id){
         return view('challenges.edit', [
             'challenge' => $challenge,
         ]);
+        }
+
+        return back()->with('status', '投稿者本人しか編集できません。');
     }
 
     public function update(ChallengesUpdateRequest $request, $challenge_id)
     {
-
         try {
-			// トランザクション開始
+            // トランザクション開始
             \DB::beginTransaction();
             
             $challenge = challenge::find($challenge_id);
             $challenge->impression = $request->impression;
 
             if(!isset($request->challenge_img)){
-                    $challenge->img = $challenge->img;
+                $challenge->img = $challenge->img;
             }else{
                 $challengeImg = $request->challenge_img;
                 $extension = $challengeImg->guessExtension();
@@ -132,6 +128,7 @@ class ChallengesController extends Controller
                 $date = Carbon::now();
                 $date = date('Ymdhis');
                 $fileName = "challenge_{$user_id}_{$date}.{$extension}";
+
                 $challenge->img = $fileName;
 
                 // imgファイル自体を保存
@@ -147,15 +144,23 @@ class ChallengesController extends Controller
                 'challenge_id' => $challenge->id,
             ]))->with('status', '「作ってみた」を更新しました');
 
-            } catch (\Exception $e) {
+        } catch (\Exception $e) {
             // エラー発生時は、DBへの保存処理が無かったことにする（ロールバック）
             \DB::rollBack();
             throw $e;
-            }
+        }
     }
 
-    public function destroy($challenge_id)
+    public function destory($challenge_id)
     {
-        
+        $challenge = Challenge::find($challenge_id);
+        $recipe_id = $challenge->recipe_id;
+
+        if(\Auth::id() == $challenge->user_id){
+            $challenge->delete();
+            return redirect(route('recipes.show', ['id' => $recipe_id]))->with('status', '「作ってみた」投稿を削除しました。');
+        }
+
+        return back()->with('status', '投稿者本人しか削除できません。');
     }
 }

--- a/resources/views/challenges/show.blade.php
+++ b/resources/views/challenges/show.blade.php
@@ -58,5 +58,24 @@
     </div>
 
   </div>
+  @if(Auth::id() == $challenge->user_id)
+  <div class="row">
+    <!-- 編集ボタン -->
+    <div class="col-5 mr-2">
+    <button onclick="location.href='{{ route('challenges.edit', ['challenge_id' => $challenge->id]) }}'" class="btn btn-lg btn-info" style="width: 100%; color: #fff;">編集</button> 
+    </div>
+    <!-- 削除ボタン -->
+    <div class="col-5">
+      <form action="{{ route('challenges.delete', ['challenge_id' => $challenge->id]) }}" method="POST">
+        {{ csrf_field() }}
+          <button type="submit" class="btn btn-lg btn-info" style="width: 100%; color: #fff;">削除</button>
+      </form>
+    </div>
+  </div>
+  @endif
 </div>
 @endsection
+
+
+
+          

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,8 +23,9 @@ Route::get('/recipes/show/{id}', 'RecipesController@show')->name('recipes.show')
 Route::get('challenges/create', 'ChallengesController@create')->name('challenges.create');
 Route::post('challenges/store', 'ChallengesController@store')->name('challenges.store');
 Route::get('challenges/show/{challenge_id}', 'ChallengesController@show')->name('challenges.show');
-Route::get('challenges/edit/{challenge_id}', 'ChallengesController@edit');
+Route::get('challenges/edit/{challenge_id}', 'ChallengesController@edit')->name('challenges.edit');
 Route::post('challenges/update/{challenge_id}', 'ChallengesController@update')->name('challenges.update');
+Route::post('challenges/delete/{challenge_id}', 'ChallengesController@destory')->name('challenges.delete');
 
 
 Auth::routes();


### PR DESCRIPTION
##作ってみたに関する削除機能　ユーザーチェック機能実装

【実装目的】
・作ってみたページから削除機能(destroy)の実装
・作ってみたページの投稿をログインユーザー以外できないようにする（ボタンは表示させたままにする）
・作ってみたページの編集・削除を投稿者以外できないようにする（ボタンも非表示にする）

【実装内容】
ChallengesControllerの
・destroyアクションを追加（ユーザーチェック機能も合わせて追加）
・editアクションにユーザーチェック機能を追加
・createアクションにAuthチェックを追加

challenges.showに
削除・編集ボタンを追加

【相談】
ログインしていない状態でも削除・編集ボタンを表示させるべきでしょうか？

【今後の予定】
favoriteの実装